### PR TITLE
docs(admin): add Help section with Graphistry iframe cross-origin runbook

### DIFF
--- a/docs/source/admin/100_Graphistry_Iframe_Blocked.md
+++ b/docs/source/admin/100_Graphistry_Iframe_Blocked.md
@@ -22,14 +22,17 @@ A mismatch between any pair causes the iframe to be blocked by the browser or to
 
 ### Graphistry side (cross-origin cookies)
 
-The Graphistry server must issue session cookies with `SameSite=None; Secure` so the browser will send them from the Louie-embedded iframe. The relevant cookie flags are managed via Graphistry server configuration — see the [Graphistry Admin Guide → Configuration places](https://graphistry-admin-docs.readthedocs.io/en/latest/app-config/configure.html#configuration-places) for where these settings live and how to set them.
+The Graphistry server must issue session cookies with `SameSite=None; Secure` so the browser will send them from the Louie-embedded iframe. The relevant cookie flags are managed via Graphistry server configuration:
+
+- [Graphistry Admin Guide → TLS hardening](https://graphistry-admin-docs.readthedocs.io/en/latest/app-config/configure.html#tls-hardening) — the cross-origin embedding section that names the cookie flags and the iframe-related Caddy headers.
+- [Graphistry Admin Guide → Configuration places](https://graphistry-admin-docs.readthedocs.io/en/latest/app-config/configure.html#configuration-places) — where these settings live on disk (`custom.env`, `Caddyfile`, etc.).
 
 Verify in browser DevTools → Application → Cookies on the Graphistry host:
 
 - Working: `SameSite=None; Secure`
 - Failing: `SameSite=Lax` → the browser drops the cookie from the Louie iframe and auth loops indefinitely.
 
-If the cookie attributes are wrong, fix them on the Graphistry side per the [Graphistry Admin Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/) and restart the Graphistry stack.
+If the cookie attributes are wrong, fix them on the Graphistry side per the [Graphistry Admin Guide → TLS hardening](https://graphistry-admin-docs.readthedocs.io/en/latest/app-config/configure.html#tls-hardening) and restart the Graphistry stack.
 
 ### Louie side (CSP and OA2_HOST)
 
@@ -53,7 +56,7 @@ Run these in order. Stop at the first mismatch.
 
 1. **Confirm origins differ.** If Louie and Graphistry share a single origin, this page is not your problem.
 2. **Inspect the browser console** on the failing page. "Refused to frame … because it violates CSP `frame-src`/`child-src`" points to the Louie CSP. A cookie warning about `SameSite` points to Graphistry cookie flags.
-3. **Check Graphistry cookies** on the Graphistry host (DevTools → Application → Cookies). Require `SameSite=None; Secure` on session cookies. If wrong, fix on the Graphistry side per the [Graphistry Admin Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/).
+3. **Check Graphistry cookies** on the Graphistry host (DevTools → Application → Cookies). Require `SameSite=None; Secure` on session cookies. If wrong, fix on the Graphistry side per the [Graphistry Admin Guide → TLS hardening](https://graphistry-admin-docs.readthedocs.io/en/latest/app-config/configure.html#tls-hardening).
 4. **Check Louie's CSP response header** (DevTools → Network → the Louie HTML response). Confirm `frame-src` and `child-src` both include the Graphistry host literally.
 5. **Compare hostnames.** `OA2_HOST` in `$LOUIE_HOME/data/custom.env` should be byte-identical to the Graphistry host in CSP and to the host the browser actually loads Graphistry from (follow redirects).
 
@@ -61,7 +64,7 @@ Run these in order. Stop at the first mismatch.
 
 Apply the missing piece from the checklist above, then restart the affected service.
 
-For Graphistry-side cookie changes, restart the Graphistry stack per the [Graphistry Admin Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/).
+For Graphistry-side cookie changes, restart the Graphistry stack per the [Graphistry Admin Guide → TLS hardening](https://graphistry-admin-docs.readthedocs.io/en/latest/app-config/configure.html#tls-hardening).
 
 For Louie-side CSP or `OA2_HOST` changes:
 
@@ -75,4 +78,4 @@ Reload the Louie page in a fresh browser context (clear the Graphistry cookies f
 ## Related docs
 
 - Louie authentication configuration: [Authentication Registration & TLS](https://louieai-documentation.readthedocs.io/en/latest/admin/011_Authentication_Registration.html) — covers `OA2_HOST`, `OA2_REDIRECT_URL_BASE`, and the Caddy TLS pattern.
-- [Graphistry Admin Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/) — server configuration, cookie flags, and TLS setup for the Graphistry server.
+- [Graphistry Admin Guide → TLS hardening](https://graphistry-admin-docs.readthedocs.io/en/latest/app-config/configure.html#tls-hardening) — `COOKIE_SECURE`, `COOKIE_SAMESITE`, and the iframe-related Caddy headers on the Graphistry server.

--- a/docs/source/admin/100_Graphistry_Iframe_Blocked.md
+++ b/docs/source/admin/100_Graphistry_Iframe_Blocked.md
@@ -1,0 +1,91 @@
+# Graphistry Iframe Blocked in Louie
+
+Diagnose and fix "This content is blocked. Contact the site owner to fix the issue." (or blank/looping iframe) when a Louie thread renders a Graphistry graph.
+
+## When this applies
+
+Louie and Graphistry are deployed on **different origins** (different hostnames, or different subdomains with different cookie scopes), even if they sit behind the same proxy or on the same box. Cross-origin embedding depends on **cookie policy and CSP alignment** — not on `X-Frame-Options` alone.
+
+If Louie and Graphistry are served from the exact same origin, this runbook does not apply.
+
+## Three-way host alignment
+
+For cross-origin iframes to authenticate and render, **three hosts must be the same value**:
+
+1. Louie's `OA2_HOST` (the Graphistry OAuth2 host Louie redirects users to)
+2. The Graphistry browser-facing host that serves the iframe
+3. The host listed in Louie Caddy's CSP `frame-src` **and** `child-src`
+
+A mismatch between any pair causes the iframe to be blocked by the browser or to loop on auth.
+
+## Required settings
+
+### Graphistry side (cross-origin cookies)
+
+In the Graphistry server's `custom.env`:
+
+```bash
+COOKIE_SECURE=true
+COOKIE_SAMESITE=None
+```
+
+These are the defaults. Confirm they are not overridden by a site-specific `custom.env`.
+
+Symptom of a wrong value: Graphistry session cookies come back as `SameSite=Lax`, so the browser drops them from the Louie-embedded iframe and auth loops indefinitely.
+
+Verify in the browser DevTools → Application → Cookies on the Graphistry host:
+
+- Working: `SameSite=None; Secure`
+- Failing: `SameSite=Lax`
+
+### Louie side (CSP and OA2_HOST)
+
+In Louie's Caddy config, the Graphistry host must appear in **both** `frame-src` and `child-src`:
+
+```
+Content-Security-Policy "... frame-src 'self' https://your.graphistry-server.xyz; child-src 'self' https://your.graphistry-server.xyz; ..."
+```
+
+In Louie's `custom.env`:
+
+```bash
+OA2_HOST='https://your.graphistry-server.xyz'
+```
+
+The hostname in `OA2_HOST` must exactly match the CSP entries above and the host actually serving Graphistry to the browser.
+
+## Diagnosis checklist
+
+Run these in order. Stop at the first mismatch.
+
+1. **Confirm origins differ.** If Louie and Graphistry share a single origin, this page is not your problem.
+2. **Inspect the browser console** on the failing page. "Refused to frame … because it violates CSP `frame-src`/`child-src`" points to the Louie CSP. A cookie warning about `SameSite` points to Graphistry cookie flags.
+3. **Check Graphistry cookies** on the Graphistry host (DevTools → Application → Cookies). Require `SameSite=None; Secure` on session cookies.
+4. **Check Louie's CSP response header** (DevTools → Network → the Louie HTML response). Confirm `frame-src` and `child-src` both include the Graphistry host literally.
+5. **Compare hostnames.** `OA2_HOST` value in Louie's `custom.env` should be byte-identical to the Graphistry host in CSP and to the host the browser actually loads Graphistry from (follow redirects).
+6. **Confirm Graphistry `custom.env`** does not override `COOKIE_SECURE` or `COOKIE_SAMESITE`.
+
+## Fix
+
+Apply the missing piece from the checklist above, then restart the affected service:
+
+Graphistry:
+
+```bash
+cd /var/graphistry
+./dc up -d --force-recreate caddy
+```
+
+Louie:
+
+```bash
+cd /var/louie
+./dc up -d --force-recreate caddy louie api
+```
+
+Reload the Louie page in a fresh browser context (clear the Graphistry cookies first if you changed cookie flags).
+
+## Related docs
+
+- Louie authentication configuration: [Authentication Registration & TLS](011_Authentication_Registration.md) — covers `OA2_HOST`, `OA2_REDIRECT_URL_BASE`, and the Caddy TLS pattern.
+- Graphistry server administration: [graphistry/graphistry-cli](https://github.com/graphistry/graphistry-cli) — server profiles, cookie flags, and test steps for cross-origin vs single-origin embedding.

--- a/docs/source/admin/100_Graphistry_Iframe_Blocked.md
+++ b/docs/source/admin/100_Graphistry_Iframe_Blocked.md
@@ -22,21 +22,14 @@ A mismatch between any pair causes the iframe to be blocked by the browser or to
 
 ### Graphistry side (cross-origin cookies)
 
-In the Graphistry server's `custom.env`:
+The Graphistry server must issue session cookies with `SameSite=None; Secure` so the browser will send them from the Louie-embedded iframe. The relevant cookie flags are managed via Graphistry server configuration — see the [Graphistry Admin Guide → Configuration places](https://graphistry-admin-docs.readthedocs.io/en/latest/app-config/configure.html#configuration-places) for where these settings live and how to set them.
 
-```bash
-COOKIE_SECURE=true
-COOKIE_SAMESITE=None
-```
-
-These are the defaults. Confirm they are not overridden by a site-specific `custom.env`.
-
-Symptom of a wrong value: Graphistry session cookies come back as `SameSite=Lax`, so the browser drops them from the Louie-embedded iframe and auth loops indefinitely.
-
-Verify in the browser DevTools → Application → Cookies on the Graphistry host:
+Verify in browser DevTools → Application → Cookies on the Graphistry host:
 
 - Working: `SameSite=None; Secure`
-- Failing: `SameSite=Lax`
+- Failing: `SameSite=Lax` → the browser drops the cookie from the Louie iframe and auth loops indefinitely.
+
+If the cookie attributes are wrong, fix them on the Graphistry side per the [Graphistry Admin Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/) and restart the Graphistry stack.
 
 ### Louie side (CSP and OA2_HOST)
 
@@ -46,7 +39,7 @@ In Louie's Caddy config, the Graphistry host must appear in **both** `frame-src`
 Content-Security-Policy "... frame-src 'self' https://your.graphistry-server.xyz; child-src 'self' https://your.graphistry-server.xyz; ..."
 ```
 
-In Louie's `custom.env`:
+In Louie's `$LOUIE_HOME/data/custom.env`:
 
 ```bash
 OA2_HOST='https://your.graphistry-server.xyz'
@@ -60,26 +53,20 @@ Run these in order. Stop at the first mismatch.
 
 1. **Confirm origins differ.** If Louie and Graphistry share a single origin, this page is not your problem.
 2. **Inspect the browser console** on the failing page. "Refused to frame … because it violates CSP `frame-src`/`child-src`" points to the Louie CSP. A cookie warning about `SameSite` points to Graphistry cookie flags.
-3. **Check Graphistry cookies** on the Graphistry host (DevTools → Application → Cookies). Require `SameSite=None; Secure` on session cookies.
+3. **Check Graphistry cookies** on the Graphistry host (DevTools → Application → Cookies). Require `SameSite=None; Secure` on session cookies. If wrong, fix on the Graphistry side per the [Graphistry Admin Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/).
 4. **Check Louie's CSP response header** (DevTools → Network → the Louie HTML response). Confirm `frame-src` and `child-src` both include the Graphistry host literally.
-5. **Compare hostnames.** `OA2_HOST` value in Louie's `custom.env` should be byte-identical to the Graphistry host in CSP and to the host the browser actually loads Graphistry from (follow redirects).
-6. **Confirm Graphistry `custom.env`** does not override `COOKIE_SECURE` or `COOKIE_SAMESITE`.
+5. **Compare hostnames.** `OA2_HOST` in `$LOUIE_HOME/data/custom.env` should be byte-identical to the Graphistry host in CSP and to the host the browser actually loads Graphistry from (follow redirects).
 
 ## Fix
 
-Apply the missing piece from the checklist above, then restart the affected service:
+Apply the missing piece from the checklist above, then restart the affected service.
 
-Graphistry:
+For Graphistry-side cookie changes, restart the Graphistry stack per the [Graphistry Admin Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/).
 
-```bash
-cd /var/graphistry
-./dc up -d --force-recreate caddy
-```
-
-Louie:
+For Louie-side CSP or `OA2_HOST` changes:
 
 ```bash
-cd /var/louie
+cd $LOUIE_HOME
 ./dc up -d --force-recreate caddy louie api
 ```
 
@@ -87,5 +74,5 @@ Reload the Louie page in a fresh browser context (clear the Graphistry cookies f
 
 ## Related docs
 
-- Louie authentication configuration: [Authentication Registration & TLS](011_Authentication_Registration.md) — covers `OA2_HOST`, `OA2_REDIRECT_URL_BASE`, and the Caddy TLS pattern.
-- Graphistry server administration: [graphistry/graphistry-cli](https://github.com/graphistry/graphistry-cli) — server profiles, cookie flags, and test steps for cross-origin vs single-origin embedding.
+- Louie authentication configuration: [Authentication Registration & TLS](https://louieai-documentation.readthedocs.io/en/latest/admin/011_Authentication_Registration.html) — covers `OA2_HOST`, `OA2_REDIRECT_URL_BASE`, and the Caddy TLS pattern.
+- [Graphistry Admin Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/) — server configuration, cookie flags, and TLS setup for the Graphistry server.

--- a/docs/source/admin/help.rst
+++ b/docs/source/admin/help.rst
@@ -1,0 +1,9 @@
+Help & Troubleshooting
+======================
+
+Runbooks for common deployment issues. Each page lists symptom, diagnosis steps, and fix.
+
+.. toctree::
+   :maxdepth: 1
+
+   100_Graphistry_Iframe_Blocked

--- a/docs/source/admin/index.rst
+++ b/docs/source/admin/index.rst
@@ -10,6 +10,7 @@ Admin Guide
    configuration
    security
    maintenance
+   help
 
 The Louie Admin Guide Documentation covers:
 


### PR DESCRIPTION
## Summary
- New **Help & Troubleshooting** section under the admin guide (`admin/help.rst`), linked from `admin/index.rst`.
- First runbook: `100_Graphistry_Iframe_Blocked.md` — symptom, three-way host alignment (`OA2_HOST` ↔ Graphistry host ↔ Caddy CSP `frame-src`/`child-src`), required Graphistry cookie flags (`COOKIE_SECURE=true`, `COOKIE_SAMESITE=None`), diagnosis checklist, and fix steps.
- Cross-links to existing `011_Authentication_Registration.md` and out to [graphistry/graphistry-cli](https://github.com/graphistry/graphistry-cli) (per Leo's plan: avoid duplication via cross-linking).

Sourced from Trello card [228](https://trello.com/c/i1v1nLMu/228-discovery-graphistry-iframe-blocked-in-louie-cross-origin-embedding-docs-diagnosis-runbook) (discovery Slack thread + Codex cross-repo research report, 2026-04-20).

## Test plan
- [ ] Build docs: `./bin/html.sh` (or `docker compose build --no-cache sphinx` if cached)
- [ ] Serve: `cd docs/build/html && python3 -m http.server 8000`
- [ ] Visit http://localhost:8000/admin/help.html — landing page renders
- [ ] Visit http://localhost:8000/admin/100_Graphistry_Iframe_Blocked.html — runbook renders, headings clean, code blocks formatted
- [ ] Admin sidebar/toctree shows "Help & Troubleshooting" after Maintenance
- [ ] Internal link to `011_Authentication_Registration.html` resolves
- [ ] External graphistry-cli link works
- [ ] No new Sphinx warnings referencing `100_Graphistry_Iframe_Blocked` or `help.rst`

## Follow-ups (out of scope)
- Graphistry-side admin profiles doc in [graphistry/graphistry-cli](https://github.com/graphistry/graphistry-cli) (cross-origin vs single-origin embedding server profiles).
- Failure-mode matrix §7 + operator test script from the Codex report, once the graphistry-cli doc lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)