### PR TITLE
docs(skills): add Skills and Skill Authoring user guides

### DIFF
--- a/docs/source/user/069_Skills.md
+++ b/docs/source/user/069_Skills.md
@@ -31,16 +31,11 @@ Each skill requires a `SKILL.md` file as its entry point. You can create a skill
 
 ## How Skills Load into the Agent
 
-Once a skill is activated for a conversation, its content is included in the agent's context. There are limits on how much skill content fits:
+Once a skill is activated for a conversation, its content is included in the agent's context. There is a limit to how much skill content fits at once.
 
-| Budget | Value |
-|--------|-------|
-| Total across all active skills | ~10,000 tokens (40,000 characters) |
-| Per skill | ~5,000 tokens (20,000 characters) |
+When active skills exceed the budget, the least-recently-used skill content is trimmed first (resource file listings are removed but the main document stays), then entire skills are evicted if needed. The most recently activated skill is never evicted. The agent is notified when content is trimmed so it can request specific sections on demand.
 
-When active skills exceed the total budget, the least-recently-used skill content is trimmed first (resource file listings are removed but the main document stays), then entire skills are evicted if needed. The most recently activated skill is never evicted. The agent is notified when content is trimmed so it can request specific sections on demand.
-
-**Practical guidance:** Keep your main `SKILL.md` focused and concise. Put large reference content in separate resource files - the agent can fetch those on demand when it needs them.
+**Practical guidance:** Keep each skill focused and concise - aim for ~500 lines or fewer. Put large reference content in separate resource files and split broad topics across multiple focused skills; the agent can fetch what it needs on demand.
 
 ## Activation Scopes
 
@@ -56,7 +51,7 @@ Use `session` for domain knowledge relevant to a whole work session. Use `explic
 
 ## Using Multiple Skills
 
-An organization can have up to 100 skills. The agent reads all their descriptions in every conversation, so write descriptions that clearly distinguish when each skill applies. Skills with vague or overlapping descriptions lead to the agent activating the wrong one.
+Organizations can have multiple skills. The agent reads all their descriptions in every conversation, so write descriptions that clearly distinguish when each skill applies. Skills with vague or overlapping descriptions lead to the agent activating the wrong one.
 
 ## Importing and Exporting
 

--- a/docs/source/user/069_Skills.md
+++ b/docs/source/user/069_Skills.md
@@ -1,0 +1,65 @@
+# Skills
+
+Skills are packages of specialized knowledge that you give to your agent. Each skill is a collection of markdown files (and optionally Python scripts) that teaches the agent how to handle a particular domain, workflow, or task - without you having to explain it every time.
+
+You manage skills through the Skills panel in the UI or via the `/api/skills` endpoints.
+
+## What Skills Do
+
+When you start a conversation, the agent sees a catalog of all available skills for your organization. It reads the name and description of each skill to decide which ones are relevant, then loads the full content of those it needs.
+
+This two-step approach keeps the agent's context lean: the catalog is lightweight, and only activated skills consume context space.
+
+## Creating a Skill
+
+Each skill requires a `SKILL.md` file as its entry point. You can create a skill:
+
+- **In the UI** - through the Skills management panel
+- **Via the API** - `POST /api/skills` with a name and description, then write files via the files endpoints
+- **By importing an archive** - `POST /api/skills/import` with a `.zip` or `.tar.gz` containing a `SKILL.md`
+- **By asking the agent** - the agent can create skills for you when asked
+
+### Skill Limits
+
+| Limit | Value |
+|-------|-------|
+| Skills per organization | 100 |
+| Files per skill | 20 |
+| Size per file | 100 KB |
+| Total size per skill | 500 KB |
+| Allowed file types | `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.py`, `.xml` |
+
+## How Skills Load into the Agent
+
+Once a skill is activated for a conversation, its content is included in the agent's context. There are limits on how much skill content fits:
+
+| Budget | Value |
+|--------|-------|
+| Total across all active skills | ~10,000 tokens (40,000 characters) |
+| Per skill | ~5,000 tokens (20,000 characters) |
+
+When active skills exceed the total budget, the least-recently-used skill content is trimmed first (resource file listings are removed but the main document stays), then entire skills are evicted if needed. The most recently activated skill is never evicted. The agent is notified when content is trimmed so it can request specific sections on demand.
+
+**Practical guidance:** Keep your main `SKILL.md` focused and concise. Put large reference content in separate resource files - the agent can fetch those on demand when it needs them.
+
+## Activation Scopes
+
+When a skill is activated for a conversation, it can have one of three scopes:
+
+| Scope | Lifetime |
+|-------|---------|
+| `run` | Active for one agent response only |
+| `session` | Active for the entire conversation |
+| `explicit` | Active until manually deactivated |
+
+Use `session` for domain knowledge relevant to a whole work session. Use `explicit` for skills that should always be available, like company-specific standards or recurring workflows.
+
+## Using Multiple Skills
+
+An organization can have up to 100 skills. The agent reads all their descriptions in every conversation, so write descriptions that clearly distinguish when each skill applies. Skills with vague or overlapping descriptions lead to the agent activating the wrong one.
+
+## Importing and Exporting
+
+You can package a skill as a `.zip` or `.tar.gz` archive for sharing or backup. The archive must contain a `SKILL.md` at the root or top-level folder. All other files in the archive are imported as resource files.
+
+See [Skill Authoring](070_Skill_Authoring) for how to write effective skill content.

--- a/docs/source/user/070_Skill_Authoring.md
+++ b/docs/source/user/070_Skill_Authoring.md
@@ -8,7 +8,7 @@ See [Skills](069_Skills) for skill management and limits.
 
 Every skill starts with a `SKILL.md`. This is what the agent reads when it activates your skill. It must follow this structure:
 
-```markdown
+`````markdown
 ---
 name: my-skill-name
 description: One-line description used for discovery and triggering
@@ -33,7 +33,7 @@ example here
 
 ## Troubleshooting
 ...
-```
+`````
 
 ### Frontmatter
 
@@ -137,7 +137,7 @@ Scripts receive arguments via `sys.argv[1:]`.
 
 ## Example: Minimal Valid SKILL.md
 
-```markdown
+`````markdown
 ---
 name: splunk-query-helper
 description: Helps write and optimize Splunk SPL queries. Use when asked to search
@@ -173,4 +173,4 @@ index=main source=/var/log/app.log level=ERROR earliest=-24h@h
 ## Troubleshooting
 - **No results:** Check index name and time range; confirm field names with `| fieldsummary`
 - **Slow search:** Add `index=` filter; avoid leading wildcards in field values
-```
+`````

--- a/docs/source/user/070_Skill_Authoring.md
+++ b/docs/source/user/070_Skill_Authoring.md
@@ -1,0 +1,176 @@
+# Skill Authoring Guide
+
+How to write a skill that the agent discovers correctly, loads efficiently, and uses well.
+
+See [Skills](069_Skills) for skill management and limits.
+
+## SKILL.md Structure
+
+Every skill starts with a `SKILL.md`. This is what the agent reads when it activates your skill. It must follow this structure:
+
+```markdown
+---
+name: my-skill-name
+description: One-line description used for discovery and triggering
+---
+
+# My Skill Name
+
+## When to Use
+...
+
+## Capabilities
+...
+
+## Workflow
+...
+
+## Patterns
+```bash
+# At least one code example is required
+example here
+```
+
+## Troubleshooting
+...
+```
+
+### Frontmatter
+
+The `---` block at the top is required. Both fields are mandatory:
+
+| Field | Rules |
+|-------|-------|
+| `name` | Lowercase letters, numbers, and hyphens only; 1-64 characters; e.g. `splunk-query-helper` |
+| `description` | At least 10 characters; up to 1,024 characters; written for the agent to read during discovery |
+
+**Write the description for triggering.** The agent reads only the name and description before deciding whether to activate a skill. Be specific about what situations warrant this skill. Vague descriptions cause missed activations or false positives.
+
+Good: `"Helps write and optimize Splunk SPL queries. Use when asked to search Splunk, write a SPL query, or debug a search returning unexpected results."`
+
+Too vague: `"Helps with log analysis."`
+
+### Required Sections
+
+The validator requires **at least 3 of these 5 section headers** (the `##` headings, case-insensitive):
+
+- `## When to Use`
+- `## Capabilities`
+- `## Workflow`
+- `## Patterns`
+- `## Troubleshooting`
+
+At least one fenced code block (` ``` `) must appear somewhere in the document.
+
+The document must begin with an H1 title (`# Skill Name`).
+
+## Single-file vs Multifile Skills
+
+**Single-file:** Everything in `SKILL.md`. Right for focused, self-contained skills that fit within about 5,000 tokens of content.
+
+**Multifile:** `SKILL.md` is a lean table of contents. The detail lives in resource files that the agent fetches on demand. Good for large reference docs, template libraries, or anything that would bloat the main document.
+
+Conventional folder layout for multifile skills:
+
+```
+SKILL.md                    # Lean index - when/how to use + list of resources
+references/                 # Reference docs, specs, API descriptions
+templates/                  # Reusable output templates
+examples/                   # Example inputs and outputs
+scripts/                    # Executable Python scripts
+```
+
+In multifile mode, the validator relaxes its section requirements (only 1 required instead of 3, no code block required) because the detail lives elsewhere.
+
+The agent sees a listing of available resource files at the bottom of the activated skill block. It requests specific files using the `read_skill_resource` tool, so only what it actually needs lands in context.
+
+## Writing for Context Budget
+
+Active skill content is budget-capped. Each skill gets up to ~5,000 tokens (~20,000 characters), and all active skills share a total of ~10,000 tokens (~40,000 characters).
+
+When the budget is exceeded, the least-recently-used skill content is trimmed. The agent is told what was cut so it can request sections on demand.
+
+**What this means for authoring:**
+- Keep `SKILL.md` under ~15,000 characters to stay well within the per-skill cap
+- Move large command references, example outputs, and lengthy specs into resource files under `references/`
+- Prefer concise, scannable sections over exhaustive prose
+- Use tables and bullet lists rather than paragraphs where possible
+
+## Python Scripts
+
+Skills can include executable Python scripts in a `scripts/` subfolder. The agent can run these via the `run_skill_script` tool.
+
+Declare dependencies inline using PEP 723 metadata (preferred):
+
+```python
+# /// script
+# dependencies = ["requests>=2.28", "pandas"]
+# ///
+
+def main():
+    import requests
+    # ...
+
+main()
+```
+
+Or list them in `scripts/requirements.txt`, one package per line.
+
+Two extra functions are available to scripts at runtime:
+
+- `save_artifact(name, content, content_type)` - attach a file or output to the cell
+- `emit_event(event_type, data)` - send an event to the frontend
+
+Scripts receive arguments via `sys.argv[1:]`.
+
+## Practical Tips
+
+**Name your skill for its trigger, not its topic.** `fix-kubernetes-oom` is better than `kubernetes` - the agent knows exactly when to reach for it.
+
+**One skill, one job.** Skills with broad scope activate when they shouldn't and miss when they should. A focused skill with a crisp description outperforms a catch-all every time.
+
+**Put the "when to use" section first.** The agent reads top-to-bottom; put activation criteria early so it confirms this is the right skill before reading the rest.
+
+**Test your description.** Ask yourself: if an agent saw only the name and description, would it activate this skill at the right moment? Would it skip it at the wrong moment?
+
+**Version your content, not your skill names.** Rename or update a skill's files rather than creating `my-skill-v2`. The skill's name is its identity in the catalog.
+
+## Example: Minimal Valid SKILL.md
+
+```markdown
+---
+name: splunk-query-helper
+description: Helps write and optimize Splunk SPL queries. Use when asked to search
+  Splunk, write a SPL query, or debug a search returning unexpected results.
+---
+
+# Splunk Query Helper
+
+## When to Use
+- User asks to search Splunk for events
+- User has a slow or incorrect SPL query to debug
+- User wants to understand Splunk search syntax
+
+## Capabilities
+- Generate SPL queries from natural language descriptions
+- Identify common performance antipatterns (missing index filter, wildcard prefix)
+- Translate between SPL and other query languages
+
+## Workflow
+1. Identify the target index and time range from user context
+2. Draft the SPL query
+3. Check for performance issues (index filter first, field extraction order)
+4. Return the query with a brief explanation
+
+## Patterns
+```spl
+# Always filter by index first for performance
+index=main source=/var/log/app.log level=ERROR earliest=-24h@h
+| stats count by host
+| sort -count
+```
+
+## Troubleshooting
+- **No results:** Check index name and time range; confirm field names with `| fieldsummary`
+- **Slow search:** Add `index=` filter; avoid leading wildcards in field values
+```

--- a/docs/source/user/070_Skill_Authoring.md
+++ b/docs/source/user/070_Skill_Authoring.md
@@ -6,14 +6,35 @@ See [Skills](069_Skills) for skill management and limits.
 
 ## SKILL.md Structure
 
-Every skill starts with a `SKILL.md`. This is what the agent reads when it activates your skill. It must follow this structure:
+Every skill starts with a `SKILL.md`. The only strictly required part is the YAML frontmatter at the top - everything else is recommended structure that helps the agent understand and use the skill effectively.
+
+### Required: Frontmatter
+
+The `---` block must appear at the very top. Both fields are required:
 
 `````markdown
 ---
 name: my-skill-name
 description: One-line description used for discovery and triggering
 ---
+`````
 
+| Field | Rules |
+|-------|-------|
+| `name` | Lowercase letters, numbers, and hyphens only; 1-64 characters; e.g. `splunk-query-helper` |
+| `description` | Written for the agent to read during discovery; be specific about when this skill applies |
+
+**Write the description for triggering.** The agent reads only the name and description before deciding whether to activate a skill. Be specific about what situations warrant this skill. Vague descriptions cause missed activations or false positives.
+
+Good: `"Helps write and optimize Splunk SPL queries. Use when asked to search Splunk, write a SPL query, or debug a search returning unexpected results."`
+
+Too vague: `"Helps with log analysis."`
+
+### Recommended Structure
+
+A well-structured `SKILL.md` begins with an H1 title and includes at least 3 of these sections (the validator checks for them and will ask you to add more if fewer than 3 are present):
+
+`````markdown
 # My Skill Name
 
 ## When to Use
@@ -27,7 +48,7 @@ description: One-line description used for discovery and triggering
 
 ## Patterns
 ```bash
-# At least one code example is required
+# Include at least one code example
 example here
 ```
 
@@ -35,50 +56,25 @@ example here
 ...
 `````
 
-### Frontmatter
-
-The `---` block at the top is required. Both fields are mandatory:
-
-| Field | Rules |
-|-------|-------|
-| `name` | Lowercase letters, numbers, and hyphens only; 1-64 characters; e.g. `splunk-query-helper` |
-| `description` | At least 10 characters; up to 1,024 characters; written for the agent to read during discovery |
-
-**Write the description for triggering.** The agent reads only the name and description before deciding whether to activate a skill. Be specific about what situations warrant this skill. Vague descriptions cause missed activations or false positives.
-
-Good: `"Helps write and optimize Splunk SPL queries. Use when asked to search Splunk, write a SPL query, or debug a search returning unexpected results."`
-
-Too vague: `"Helps with log analysis."`
-
-### Required Sections
-
-The validator requires **at least 3 of these 5 section headers** (the `##` headings, case-insensitive):
-
-- `## When to Use`
-- `## Capabilities`
-- `## Workflow`
-- `## Patterns`
-- `## Troubleshooting`
-
-At least one fenced code block (` ``` `) must appear somewhere in the document.
-
-The document must begin with an H1 title (`# Skill Name`).
+Including at least one code example is also encouraged - the validator will prompt you to add one if none are present.
 
 ## Single-file vs Multifile Skills
 
-**Single-file:** Everything in `SKILL.md`. Right for focused, self-contained skills that fit within about 5,000 tokens of content.
+**Single-file:** Everything in `SKILL.md`. Right for focused, self-contained skills - aim to keep it under ~500 lines.
 
 **Multifile:** `SKILL.md` is a lean table of contents. The detail lives in resource files that the agent fetches on demand. Good for large reference docs, template libraries, or anything that would bloat the main document.
 
 Conventional folder layout for multifile skills:
 
 ```
-SKILL.md                    # Lean index - when/how to use + list of resources
-references/                 # Reference docs, specs, API descriptions
-templates/                  # Reusable output templates
-examples/                   # Example inputs and outputs
-scripts/                    # Executable Python scripts
+SKILL.md          # Lean index - when/how to use + list of resources
+references/       # Reference docs, specs, API descriptions (conventional)
+templates/        # Reusable output templates (conventional)
+examples/         # Example inputs and outputs (conventional)
+scripts/          # Executable Python scripts (enforced - agent can run these)
 ```
+
+The `scripts/` folder is the only one with special behavior - the agent can discover and run `.py` files placed there. The other folders are naming conventions only; you can organize files however you like.
 
 In multifile mode, the validator relaxes its section requirements (only 1 required instead of 3, no code block required) because the detail lives elsewhere.
 
@@ -86,13 +82,11 @@ The agent sees a listing of available resource files at the bottom of the activa
 
 ## Writing for Context Budget
 
-Active skill content is budget-capped. Each skill gets up to ~5,000 tokens (~20,000 characters), and all active skills share a total of ~10,000 tokens (~40,000 characters).
-
-When the budget is exceeded, the least-recently-used skill content is trimmed. The agent is told what was cut so it can request sections on demand.
+There is a limit to how much skill content the agent can hold in context at once. When that limit is reached, the least-recently-used skills are trimmed - first their resource listings, then the skills themselves. The agent is told what was cut so it can request specific sections on demand.
 
 **What this means for authoring:**
-- Keep `SKILL.md` under ~15,000 characters to stay well within the per-skill cap
-- Move large command references, example outputs, and lengthy specs into resource files under `references/`
+- Keep `SKILL.md` under ~500 lines to stay comfortably within the per-skill limit
+- Move large command references, example outputs, and lengthy specs into resource files
 - Prefer concise, scannable sections over exhaustive prose
 - Use tables and bullet lists rather than paragraphs where possible
 

--- a/docs/source/user/advanced_topics.rst
+++ b/docs/source/user/advanced_topics.rst
@@ -12,4 +12,6 @@ Advanced Topics
    057_Recipes
    058_Database_tools
    064_Guard_rails
-   065_Administrators_can_set_guard_rail_prompts_on_all_or_specific_AI_tools 
+   065_Administrators_can_set_guard_rail_prompts_on_all_or_specific_AI_tools
+   069_Skills
+   070_Skill_Authoring 


### PR DESCRIPTION
## Summary

- Adds `069_Skills.md` - user-facing overview of the skills feature: what skills are, how they load into agent context, activation scopes, limits, and import/export
- Adds `070_Skill_Authoring.md` - practical guide for writing SKILL.md files: frontmatter rules, required sections, single-file vs multifile, context budget guidance, Python scripts, and tips
- Wires both pages into the Advanced Topics section of the user guide (`advanced_topics.rst`)