### PR TITLE
docs(admin): add OAuth2 setup screenshots to authentication guide

### DIFF
--- a/docs/source/admin/011_Authentication_Registration.md
+++ b/docs/source/admin/011_Authentication_Registration.md
@@ -80,7 +80,9 @@ Notify Graphistry staff with your:
 
 Configure your self-hosted Graphistry to be an OAuth2 provider for Louie
 
-TODO(tcook): add screenshots
+![OAuth2 Setup Step 1](../static/oauth-setup-01.png)
+
+![OAuth2 Setup Step 2](../static/oauth-setup-02.png)
 
 ### Steps:
 


### PR DESCRIPTION
## Summary

- Replaces `TODO(tcook): add screenshots` in the self-hosted OAuth2 setup section with the two oauth-setup images
- Images were already present in `docs/source/static/` but not yet embedded